### PR TITLE
Replace with `"0"` not `0`, since the columns are always character

### DIFF
--- a/R/xml2relational.r
+++ b/R/xml2relational.r
@@ -75,19 +75,19 @@ serial.df <- function(l, elem.df, df.name, record, prefix.primary, prefix.foreig
       else {
         if(!is.na(elem.df[record, i])) {
           serial <- append(serial, tidyr::replace_na(
-            serial.df(l, df.sub, table.name, which(df.sub[, paste0(prefix.primary, table.name)] == elem.df[record, i]), prefix.primary, prefix.foreign),0))
+            serial.df(l, df.sub, table.name, which(df.sub[, paste0(prefix.primary, table.name)] == elem.df[record, i]), prefix.primary, prefix.foreign),"0"))
         }
       }
     }
     else {
       if(stringr::str_sub(names(elem.df)[i], 1, nchar(prefix.primary)) != prefix.primary) {
-        serial <- append(serial, tidyr::replace_na(elem.df[record, i], 0))
+        serial <- append(serial, tidyr::replace_na(elem.df[record, i], "0"))
         names(serial)[NROW(serial)] <- paste0(df.name, "@", names(elem.df)[i])
       }
     }
   }
   if(NROW(serial) > 0) {
-    return(tidyr::replace_na(serial[order(names(serial))],0))
+    return(tidyr::replace_na(serial[order(names(serial))],"0"))
   }
   else return(NA)
 }
@@ -102,7 +102,7 @@ serial.xml <- function(obj) {
       else {
         ctn <- as.character(xml2::xml_contents(chdr[i]))
         if(identical(ctn, character(0))) ctn <- NA
-        serial <- append(serial, tidyr::replace_na(ctn, 0))
+        serial <- append(serial, tidyr::replace_na(ctn, "0"))
         names(serial)[NROW(serial)] <- paste0(xml2::xml_name(obj), "@", xml2::xml_name(chdr[i]))
       }
     }
@@ -121,7 +121,7 @@ find.object <- function(l, obj, prefix.primary, prefix.foreign) {
       res.df <- serial.df(l, elem.df, xml2::xml_name(obj), i, prefix.primary, prefix.foreign)
       res.xml <- serial.xml(obj)
       if(NROW(res.df) == NROW(res.xml)) {
-        if(sum(tidyr::replace_na(res.df, 0) == tidyr::replace_na(res.xml, 0)) - NROW(res.df) == 0) {
+        if(sum(tidyr::replace_na(res.df, "0") == tidyr::replace_na(res.xml, "0")) - NROW(res.df) == 0) {
           ex <- elem.df[i,paste0(prefix.primary,xml2::xml_name(obj))]
           break
         }


### PR DESCRIPTION
We are updating `tidyr::replace_na()` to utilize the vctrs package, and that results in slightly stricter / more correct type conversions. See https://github.com/tidyverse/tidyr/pull/1219

We noticed in revdeps that this package broke. An easy way to see this is by installing the PR mentioned above and running:

``` r
library(xml2relational)

# Find path to custmers.xml example file in package directory
path <- system.file("", "customers.xml", package = "xml2relational")

db <- toRelational(path)
#> Error: Can't convert `replace` <double> to match type of `data` <character>.
```

<sup>Created on 2021-11-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

The problem boils down to the fact that you are calling `replace_na(<chr>, replace = 0)`. In other words, you are trying to replace missing values in a _character_ column with a _numeric_ `0` value. This is no longer allowed.

I've updated your calls to `replace_na()` to instead use `"0"`, which is what was being used anyways. This should work with both the CRAN and dev versions of tidyr, so you can go ahead and send a patch release of your package to CRAN.

We would greatly appreciate if you could merge this PR and submit a patch release of your package to CRAN so we can send tidyr in!